### PR TITLE
Fix grid styling to be contained in content block

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -6,9 +6,9 @@
 
 
 @section('main-content')
-	<div class="container spark-screen">
+	<div class="container-fluid spark-screen">
 		<div class="row">
-			<div class="col-md-10 col-md-offset-1">
+			<div class="col-md-8 col-md-offset-2">
 				<div class="panel panel-default">
 					<div class="panel-heading">Home</div>
 


### PR DESCRIPTION
In the admin home view, the block saying "You're logged in!" overflows the content block.

By using the class `container-fluid` instead of just `container`, the bootstrap main container is contained into the content block instead of using the bootstrap fixed width.

Since it is now using 100% of the content block, I also made the panel smaller so it keeps a raisonnable width on wide screens.