### PR TITLE
Laravel 5.3 Logout MethodNotAllowed Fix

### DIFF
--- a/resources/views/layouts/partials/mainheader.blade.php
+++ b/resources/views/layouts/partials/mainheader.blade.php
@@ -148,15 +148,14 @@
                                     <a href="{{ url('/settings') }}" class="btn btn-default btn-flat">{{ trans('adminlte_lang::message.profile') }}</a>
                                 </div>
                                 <div class="pull-right">
-                                    <a href="{{ url('/logout') }}" class="btn btn-default btn-flat"
-                                       onclick="event.preventDefault();
-                                                 document.getElementById('logout-form').submit();">
-                                        {{ trans('adminlte_lang::message.signout') }}
+                                    <a href="{{ url('/logout') }}"
+                                        class="btn btn-default btn-flat"
+                                        onclick="event.preventDefault();
+                                                 document.getElementById('logout-form').submit();">{{ trans('adminlte_lang::message.signout') }}
                                     </a>
 
                                     <form id="logout-form" action="{{ url('/logout') }}" method="POST" style="display: none;">
                                         {{ csrf_field() }}
-                                        <input type="submit" value="logout" style="display: none;">
                                     </form>
 
                                 </div>


### PR DESCRIPTION
In Laravel 5.3 Logout route is "POST" instead of "GET".  Updated the code based on  @taylorotwell sample code.

https://github.com/laravel/framework/blob/7d116dc5a008e69c97f864af79ac46ab6a8d5895/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub

Replaced link with a form.
