### PR TITLE
Solve issue of fonts and JS files not found

### DIFF
--- a/public/css/all-landing.css
+++ b/public/css/all-landing.css
@@ -252,8 +252,8 @@ th {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url(/fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1);
-  src: url(/fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1?#iefix) format('embedded-opentype'), url(/fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb) format('woff2'), url(/fonts/glyphicons-halflings-regular.woff?fa2772327f55d8198301fdb8bcfc8158) format('woff'), url(/fonts/glyphicons-halflings-regular.ttf?e18bbf611f2a2e43afc071aa2f4e1512) format('truetype'), url(/fonts/glyphicons-halflings-regular.svg?89889688147bd7575d6327160d64e760#glyphicons_halflingsregular) format('svg');
+  src: url(../fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1);
+  src: url(../fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1?#iefix) format('embedded-opentype'), url(../fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb) format('woff2'), url(../fonts/glyphicons-halflings-regular.woff?fa2772327f55d8198301fdb8bcfc8158) format('woff'), url(../fonts/glyphicons-halflings-regular.ttf?e18bbf611f2a2e43afc071aa2f4e1512) format('truetype'), url(../fonts/glyphicons-halflings-regular.svg?89889688147bd7575d6327160d64e760#glyphicons_halflingsregular) format('svg');
 }
 .glyphicon {
   position: relative;

--- a/public/css/all.css
+++ b/public/css/all.css
@@ -316,8 +316,8 @@ th {
 
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url(/fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1);
-  src: url(/fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1) format("embedded-opentype"), url(/fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb) format("woff2"), url(/fonts/glyphicons-halflings-regular.woff?fa2772327f55d8198301fdb8bcfc8158) format("woff"), url(/fonts/glyphicons-halflings-regular.ttf?e18bbf611f2a2e43afc071aa2f4e1512) format("truetype"), url(/fonts/glyphicons-halflings-regular.svg?89889688147bd7575d6327160d64e760) format("svg");
+  src: url(../fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1);
+  src: url(../fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1) format("embedded-opentype"), url(../fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb) format("woff2"), url(../fonts/glyphicons-halflings-regular.woff?fa2772327f55d8198301fdb8bcfc8158) format("woff"), url(../fonts/glyphicons-halflings-regular.ttf?e18bbf611f2a2e43afc071aa2f4e1512) format("truetype"), url(../fonts/glyphicons-halflings-regular.svg?89889688147bd7575d6327160d64e760) format("svg");
 }
 
 .glyphicon {
@@ -8331,8 +8331,8 @@ button.close {
 
 @font-face {
   font-family: "Ionicons";
-  src: url(/fonts/ionicons.eot?bdf1d30681cf87986c385eea78e8de9a);
-  src: url(/fonts/ionicons.eot?bdf1d30681cf87986c385eea78e8de9a) format("embedded-opentype"), url(/fonts/ionicons.woff2?311d81961c5880647fec7eaca1221b2a) format("woff2"), url(/fonts/ionicons.woff?81414686e99c00d2921e03dd53c0ab04) format("woff"), url(/fonts/ionicons.ttf?74c652671225d6ded874a648502e5f0a) format("truetype"), url(/fonts/ionicons.svg?d9496a234c81179afbca6bf5959cc30a) format("svg");
+  src: url(../fonts/ionicons.eot?bdf1d30681cf87986c385eea78e8de9a);
+  src: url(../fonts/ionicons.eot?bdf1d30681cf87986c385eea78e8de9a) format("embedded-opentype"), url(../fonts/ionicons.woff2?311d81961c5880647fec7eaca1221b2a) format("woff2"), url(../fonts/ionicons.woff?81414686e99c00d2921e03dd53c0ab04) format("woff"), url(../fonts/ionicons.ttf?74c652671225d6ded874a648502e5f0a) format("truetype"), url(../fonts/ionicons.svg?d9496a234c81179afbca6bf5959cc30a) format("svg");
   font-weight: normal;
   font-style: normal;
 }
@@ -13032,8 +13032,8 @@ button.close {
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url(/fonts/fontawesome-webfont.eot?674f50d287a8c48dc19ba404d20fe713);
-  src: url(/fonts/fontawesome-webfont.eot?674f50d287a8c48dc19ba404d20fe713) format("embedded-opentype"), url(/fonts/fontawesome-webfont.woff2?af7ae505a9eed503f8b8e6982036873e) format("woff2"), url(/fonts/fontawesome-webfont.woff?fee66e712a8a08eef5805a46892932ad) format("woff"), url(/fonts/fontawesome-webfont.ttf?b06871f281fee6b241d60582ae9369b9) format("truetype"), url(/fonts/fontawesome-webfont.svg?912ec66d7572ff821749319396470bde) format("svg");
+  src: url(../fonts/fontawesome-webfont.eot?674f50d287a8c48dc19ba404d20fe713);
+  src: url(../fonts/fontawesome-webfont.eot?674f50d287a8c48dc19ba404d20fe713) format("embedded-opentype"), url(../fonts/fontawesome-webfont.woff2?af7ae505a9eed503f8b8e6982036873e) format("woff2"), url(../fonts/fontawesome-webfont.woff?fee66e712a8a08eef5805a46892932ad) format("woff"), url(../fonts/fontawesome-webfont.ttf?b06871f281fee6b241d60582ae9369b9) format("truetype"), url(../fonts/fontawesome-webfont.svg?912ec66d7572ff821749319396470bde) format("svg");
   font-weight: normal;
   font-style: normal;
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -316,8 +316,8 @@ th {
 
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url(/fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1);
-  src: url(/fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1) format("embedded-opentype"), url(/fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb) format("woff2"), url(/fonts/glyphicons-halflings-regular.woff?fa2772327f55d8198301fdb8bcfc8158) format("woff"), url(/fonts/glyphicons-halflings-regular.ttf?e18bbf611f2a2e43afc071aa2f4e1512) format("truetype"), url(/fonts/glyphicons-halflings-regular.svg?89889688147bd7575d6327160d64e760) format("svg");
+  src: url(../fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1);
+  src: url(../fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1) format("embedded-opentype"), url(../fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb) format("woff2"), url(../fonts/glyphicons-halflings-regular.woff?fa2772327f55d8198301fdb8bcfc8158) format("woff"), url(../fonts/glyphicons-halflings-regular.ttf?e18bbf611f2a2e43afc071aa2f4e1512) format("truetype"), url(../fonts/glyphicons-halflings-regular.svg?89889688147bd7575d6327160d64e760) format("svg");
 }
 
 .glyphicon {
@@ -8331,8 +8331,8 @@ button.close {
 
 @font-face {
   font-family: "Ionicons";
-  src: url(/fonts/ionicons.eot?bdf1d30681cf87986c385eea78e8de9a);
-  src: url(/fonts/ionicons.eot?bdf1d30681cf87986c385eea78e8de9a) format("embedded-opentype"), url(/fonts/ionicons.woff2?311d81961c5880647fec7eaca1221b2a) format("woff2"), url(/fonts/ionicons.woff?81414686e99c00d2921e03dd53c0ab04) format("woff"), url(/fonts/ionicons.ttf?74c652671225d6ded874a648502e5f0a) format("truetype"), url(/fonts/ionicons.svg?d9496a234c81179afbca6bf5959cc30a) format("svg");
+  src: url(../fonts/ionicons.eot?bdf1d30681cf87986c385eea78e8de9a);
+  src: url(../fonts/ionicons.eot?bdf1d30681cf87986c385eea78e8de9a) format("embedded-opentype"), url(../fonts/ionicons.woff2?311d81961c5880647fec7eaca1221b2a) format("woff2"), url(../fonts/ionicons.woff?81414686e99c00d2921e03dd53c0ab04) format("woff"), url(../fonts/ionicons.ttf?74c652671225d6ded874a648502e5f0a) format("truetype"), url(../fonts/ionicons.svg?d9496a234c81179afbca6bf5959cc30a) format("svg");
   font-weight: normal;
   font-style: normal;
 }
@@ -13032,8 +13032,8 @@ button.close {
 
 @font-face {
   font-family: 'FontAwesome';
-  src: url(/fonts/fontawesome-webfont.eot?674f50d287a8c48dc19ba404d20fe713);
-  src: url(/fonts/fontawesome-webfont.eot?674f50d287a8c48dc19ba404d20fe713) format("embedded-opentype"), url(/fonts/fontawesome-webfont.woff2?af7ae505a9eed503f8b8e6982036873e) format("woff2"), url(/fonts/fontawesome-webfont.woff?fee66e712a8a08eef5805a46892932ad) format("woff"), url(/fonts/fontawesome-webfont.ttf?b06871f281fee6b241d60582ae9369b9) format("truetype"), url(/fonts/fontawesome-webfont.svg?912ec66d7572ff821749319396470bde) format("svg");
+  src: url(../fonts/fontawesome-webfont.eot?674f50d287a8c48dc19ba404d20fe713);
+  src: url(../fonts/fontawesome-webfont.eot?674f50d287a8c48dc19ba404d20fe713) format("embedded-opentype"), url(../fonts/fontawesome-webfont.woff2?af7ae505a9eed503f8b8e6982036873e) format("woff2"), url(../fonts/fontawesome-webfont.woff?fee66e712a8a08eef5805a46892932ad) format("woff"), url(../fonts/fontawesome-webfont.ttf?b06871f281fee6b241d60582ae9369b9) format("truetype"), url(../fonts/fontawesome-webfont.svg?912ec66d7572ff821749319396470bde) format("svg");
   font-weight: normal;
   font-style: normal;
 }

--- a/public/css/bootstrap.css
+++ b/public/css/bootstrap.css
@@ -252,8 +252,8 @@ th {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url(/fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1);
-  src: url(/fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1?#iefix) format('embedded-opentype'), url(/fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb) format('woff2'), url(/fonts/glyphicons-halflings-regular.woff?fa2772327f55d8198301fdb8bcfc8158) format('woff'), url(/fonts/glyphicons-halflings-regular.ttf?e18bbf611f2a2e43afc071aa2f4e1512) format('truetype'), url(/fonts/glyphicons-halflings-regular.svg?89889688147bd7575d6327160d64e760#glyphicons_halflingsregular) format('svg');
+  src: url(../fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1);
+  src: url(../fonts/glyphicons-halflings-regular.eot?f4769f9bdb7466be65088239c12046d1?#iefix) format('embedded-opentype'), url(../fonts/glyphicons-halflings-regular.woff2?448c34a56d699c29117adc64c43affeb) format('woff2'), url(../fonts/glyphicons-halflings-regular.woff?fa2772327f55d8198301fdb8bcfc8158) format('woff'), url(../fonts/glyphicons-halflings-regular.ttf?e18bbf611f2a2e43afc071aa2f4e1512) format('truetype'), url(../fonts/glyphicons-halflings-regular.svg?89889688147bd7575d6327160d64e760#glyphicons_halflingsregular) format('svg');
 }
 .glyphicon {
   position: relative;

--- a/resources/views/layouts/landing.blade.php
+++ b/resources/views/layouts/landing.blade.php
@@ -294,7 +294,7 @@ Landing page based on Pratt: http://blacktie.co/demo/pratt/
 <!-- Bootstrap core JavaScript
 ================================================== -->
 <!-- Placed at the end of the document so the pages load faster -->
-<script src="{{ mix('/js/app-landing.js') }}"></script>
+<script src="./{{ mix('/js/app-landing.js') }}"></script>
 <script>
     $('.carousel').carousel({
         interval: 3500

--- a/resources/views/layouts/partials/scripts.blade.php
+++ b/resources/views/layouts/partials/scripts.blade.php
@@ -2,7 +2,7 @@
 
 <!-- JQuery and bootstrap are required by Laravel 5.3 in resources/assets/js/bootstrap.js-->
 <!-- Laravel App -->
-<script src="{{ mix('/js/app.js') }}" type="text/javascript"></script>
+<script src="./{{ mix('/js/app.js') }}" type="text/javascript"></script>
 
 <!-- Optionally, you can add Slimscroll and FastClick plugins.
       Both of these plugins are recommended to enhance the


### PR DESCRIPTION
This pull request is intended to solve the issue #209, where fonts and JS files are not found after fresh installation.

## Description

My changes were basically related to the URL of those resources. For the font files, I added the `..` before the URL, as it was done in previous versions of Acacha AdminLTE Laravel. For the JS files, I added `./` before the use of the use of the `mix` function.

## Motivation and context

This is necessary to make the application load the resources correctly when it is served using alias on Apache. Currently, 404 error are thrown when the application is served using alias, which is a common way to serve more than one application in the same server. It is important to say that these changes do not have side effects for users who serve the application without aliases. This PR fixes #209.

## How has this been tested?

My environment and how I tested it is described at https://github.com/acacha/adminlte-laravel/issues/209#issuecomment-287968812.

I performed the changes using an alias for my application and the served the same application without alias, to make sure it would not have side effects. It worked fine without 404 errors

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
